### PR TITLE
AIOS-2500 Rename SPM packages to have AAT prefixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         .library(name: "AATKit-Mintegral", targets: ["AATKit-Mintegral"]),
         .library(name: "AATKit-Facebook", targets: ["AATKit-Facebook"]),
         .library(name: "AATKit-DisplayIO", targets: ["AATKit-DisplayIO"]),
-
+        .library(name: "AATAppNexusAdapter", targets: ["AATAppNexusAdapter"]),
 
         // CMPs
         .library(name: "AATKit-GoogleCMP", targets: ["AATKit-GoogleCMP"]),
@@ -66,22 +66,19 @@ let package = Package(
                                                    "AATKit-GooglePartnerBidding",
                                                    "AATKit-Criteo",
                                                    "AATKit-Tappx",
-                                                   "AATKit-Facebook"
-                                                   // "AATKit-AppNexus", Issues in the privacy file
-                                                   // Missing privacyInfo file
-                                                   // "AATKit-Prebid",
+                                                   "AATKit-Facebook",
+                                                   "AATKit-AppNexus",
+                                                   "AATKit-Prebid"
                                                   ]),
 
     ],
     dependencies: [
-        // AdNetworks supporting SPM
-        .package(name: "AppLovinSDK", url: "https://github.com/AppLovin/AppLovin-MAX-Swift-Package.git", .exact("13.2.0")),
-        .package(name: "AppHarbrSDK", url: "https://github.com/GeoEdgeSDK/AppHarbrSDK.git", .exact("1.19.0")),
-        .package(name: "GoogleMobileAds", url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", .exact("12.2.0")),
-        // same as in https://github.com/googleads/swift-package-manager-google-mobile-ads package file
+        .package(url: "https://github.com/AppLovin/AppLovin-MAX-Swift-Package.git", .exact("13.2.0")),
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", .exact("12.2.0")),
+        .package(url: "https://github.com/GeoEdgeSDK/AppHarbrSDK.git", .exact("1.19.0")),
         .package(name: "GoogleUserMessagingPlatform", url: "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git", "1.1.0"..<"4.0.0"),
-        .package(name: "RTBSPM", url: "https://github.com/AddApptr/RTBSPM", .exact("1.6.2"))
-//        .package(name: "TeadsSDK", url: "https://github.com/teads/TeadsSDK-iOS", .exact("5.1.3")), Conflict with AppLovin dependency
+        .package(url: "https://github.com/AddApptr/RTBSPM.git", .exact("1.6.2")),
+        //        .package(name: "TeadsSDK", url: "https://github.com/teads/TeadsSDK-iOS", .exact("5.1.3")), Conflict in AppLovin dependency
     ],
     targets: [
         // AATKit target
@@ -91,9 +88,7 @@ let package = Package(
 
         // AATAdMobMediationAdapter target
         .target(name:"AATKit-AATAdMobMediationAdapter",
-                dependencies: [ "AATKit-GoogleMobileAds",
-                                "AATKit"
-                              ],
+                dependencies: ["AATKit-GoogleMobileAds", "AATKit"],
                 path: "./Sources/AATAdMobMediationAdapter"),
 
         // AATAdMobDSPAdapter
@@ -108,134 +103,163 @@ let package = Package(
 
         // MARK - Dependencies Targets
         .target(name: "AATKit-GoogleMobileAds",
-                dependencies: [ "AATGoogleAdsAdapter", .product(name: "GoogleMobileAds", package: "GoogleMobileAds")],
+                dependencies: [
+                    .product(name: "GoogleMobileAds", package: "swift-package-manager-google-mobile-ads"),
+                    "AATGoogleAdsAdapter",
+                ],
                 path: "./Sources/GoogleMobileAdsSources"),
 
-            .target(name: "AATKit-AppLovin",
-                    dependencies: ["AppLovinSDK", "AATAppLovinAdapter"],
-                    path: "./Sources/AppLovinSources"),
+        .target(name: "AATKit-AppLovin",
+                dependencies: [
+                    .product(name: "AppLovinSDK", package: "AppLovin-MAX-Swift-Package"),
+                    "AATAppLovinAdapter"
+                ],
+                path: "./Sources/AppLovinSources"),
 
-            .target(name: "AATKit-AppLovinMax",
-                    dependencies: ["AppLovinSDK", "AATAppLovinMaxAdapter"],
-                    path: "./Sources/AppLovinMaxSources"),
+        .target(name: "AATKit-AppLovinMax",
+                dependencies: [
+                    .product(name: "AppLovinSDK", package: "AppLovin-MAX-Swift-Package"),
+                    "AATAppLovinMaxAdapter"
+                ],
+                path: "./Sources/AppLovinMaxSources"),
 
-            .target(name:"AATKit-AppHarbr",
-                    dependencies: ["AppHarbrSDK", "AATAppHarbrAdapter"],
-                    path: "./Sources/AppHarbr"),
+        .target(name:"AATKit-AppHarbr",
+                dependencies: [
+                    .product(name: "AppHarbrSDK", package: "AppHarbrSDK"),
+                    "AATAppHarbrAdapter"
+                ],
+                path: "./Sources/AppHarbr"),
 
-            .target(name:"AATKit-AppNexus",
-                    dependencies: ["AppNexusSDK", "OMSDK_Microsoft", "AATAppNexusAdapter"],
-                    path: "./Sources/AppNexusSources"),
+        .target(name:"AATKit-AppNexus",
+                dependencies: ["AATAppNexusSDKTarget", "AATOMSDK_Microsoft", "AATAppNexusAdapter"],
+                path: "./Sources/AppNexusSources"),
 
-            .target(name:"AATKit-Amazon",
-                    dependencies: ["DTBiOSSDK", "AATAmazonAdapter"],
-                    path: "./Sources/AmazonSources"),
+        .target(name:"AATKit-Amazon",
+                dependencies: ["AATDTBiOSSDK", "AATAmazonAdapter"],
+                path: "./Sources/AmazonSources"),
 
-            .target(name:"AATKit-Criteo",
-                    dependencies: ["CriteoPublisherSdk", "AATCriteoAdapter"],
-                    path: "./Sources/CriteoSources"),
+        .target(name:"AATKit-Criteo",
+                dependencies: ["AATCriteoPublisherSdk", "AATCriteoAdapter"],
+                path: "./Sources/CriteoSources"),
 
-            .target(name:"AATKit-FeedAd",
-                    dependencies: ["FeedAd", "AATFeedAdAdapter"],
-                    path: "./Sources/FeedAdSources"),
+        .target(name:"AATKit-FeedAd",
+                dependencies: ["AATFeedAd", "AATFeedAdAdapter"],
+                path: "./Sources/FeedAdSources"),
 
-            .target(name:"AATKit-GraviteRTB",
-                    dependencies: ["RTBSPM", "AATGraviteRTBAdapter"],
-                    path: "./Sources/GraviteRTB"),
+        .target(name:"AATKit-GraviteRTB",
+                dependencies: [
+                    .product(name: "RTBSPM", package: "RTBSPM"),
+                    "AATGraviteRTBAdapter"
+                ],
+                path: "./Sources/GraviteRTB"),
 
-            .target(name:"AATKit-OgurySdk",
-                    dependencies: ["OgurySdk", "OguryAds", "OguryCore", "OMSDK_Ogury", "AATOguryAdapter"],
-                    path: "./Sources/OguryAdsSources"),
+        .target(name:"AATKit-OgurySdk",
+                dependencies: ["AATOgurySdk", "AATOguryAds", "AATOguryCore", "AATOMSDK_Ogury", "AATOguryAdapter"],
+                path: "./Sources/OguryAdsSources"),
 
-            .target(name:"AATKit-GoogleCMP",
-                    dependencies: [.product(name: "GoogleUserMessagingPlatform", package: "GoogleUserMessagingPlatform"), "AATGoogleCMPAdapter"],
-                    path: "./Sources/GoogleCMPSources"),
+        .target(name:"AATKit-GoogleCMP",
+                dependencies: [.product(name: "GoogleUserMessagingPlatform", package: "GoogleUserMessagingPlatform"), "AATGoogleCMPAdapter"],
+                path: "./Sources/GoogleCMPSources"),
 
 
-            .target(name:"AATKit-Facebook",
-                    dependencies: ["AATKit-GoogleMobileAds", "AATFacebookAdapter", "FBAudienceNetwork", "MetaAdapter"],
-                    path: "./Sources/FacebookSources"),
+        .target(name:"AATKit-Facebook",
+                dependencies: ["AATKit-GoogleMobileAds", "AATFacebookAdapter", "AATFBAudienceNetwork", "AATMetaAdapter"],
+                path: "./Sources/FacebookSources"),
 
-            .target(name:"AATKit-Smaato",
-                    dependencies: ["OMSDK_Smaato",
-                                   "SmaatoSDKBanner",
-                                   "SmaatoSDKCore",
-                                   "SmaatoSDKInterstitial",
-                                   "SmaatoSDKNative",
-                                   "SmaatoSDKOpenMeasurement",
-                                   "SmaatoSDKOutstream",
-                                   "SmaatoSDKRewardedAds",
-                                   "SmaatoSDKRichMedia",
-                                   "SmaatoSDKVideo",
-                                   "AATSmaatoAdapter"],
-                    path: "./Sources/SmaatoSources"),
+        .target(name:"AATKit-Smaato",
+                dependencies: [
+                    "AATOMSDK_Smaato",
+                    "AATSmaatoSDKBanner",
+                    "AATSmaatoSDKCore",
+                    "AATSmaatoSDKInterstitial",
+                    "AATSmaatoSDKNative",
+                    "AATSmaatoSDKOpenMeasurement",
+                    "AATSmaatoSDKOutstream",
+                    "AATSmaatoSDKRewardedAds",
+                    "AATSmaatoSDKRichMedia",
+                    "AATSmaatoSDKVideo",
+                    "AATSmaatoAdapter"
+                ],
+                path: "./Sources/SmaatoSources"),
 
-            .target(name:"AATKit-SmartAd",
-                    dependencies: ["SASDisplayKit", "AATSmartAdAdapter"],
-                    path: "./Sources/SmartAdSources"),
+        .target(name:"AATKit-SmartAd",
+                dependencies: ["AATSASDisplayKit", "AATSmartAdAdapter"],
+                path: "./Sources/SmartAdSources"),
 
-            .target(name:"AATKit-Tappx",
-                    dependencies: ["Tappx", "OMSDK_Tappx", "AATTappxAdapter"],
-                    path: "./Sources/Tappx"),
+        .target(name:"AATKit-Tappx",
+                dependencies: ["AATTappx", "AATOMSDK_Tappx", "AATTappxAdapter"],
+                path: "./Sources/Tappx"),
 
-            .target(name:"AATKit-Teads",
-                    dependencies: ["TeadsSDK", "OMSDK_Teadstv", "AATTeadsAdapter"],
-                    path: "./Sources/TeadsSources"),
+        .target(name:"AATKit-Teads",
+                dependencies: ["AATTeadsSDK", "AATOMSDK_Teadstv", "AATTeadsAdapter"],
+                path: "./Sources/TeadsSources"),
 
-            .target(name:"AATKit-YOC",
-                    dependencies: ["VisxSDK", "AATYOCAdapter"],
-                    path: "./Sources/YOCSources"),
+        .target(name:"AATKit-YOC",
+                dependencies: ["AATVisxSDK", "AATYOCAdapter"],
+                path: "./Sources/YOCSources"),
 
-            .target(name:"AATKit-InMobi",
-                    dependencies: ["InMobiSDK", "AATInMobiAdapter"],
-                    path: "./Sources/InMobiSources"),
+        .target(name:"AATKit-InMobi",
+                dependencies: ["AATInMobiSDK", "AATInMobiAdapter"],
+                path: "./Sources/InMobiSources"),
 
-            .target(name:"AATKit-IronSource",
-                    dependencies: ["IronSource", "AATIronSourceAdapter"],
-                    path: "./Sources/IronSourceSources"),
+        .target(name:"AATKit-IronSource",
+                dependencies: ["AATIronSource", "AATIronSourceAdapter"],
+                path: "./Sources/IronSourceSources"),
 
-            .target(name:"AATKit-Kidoz",
-                    dependencies: ["Kidoz", "AATKidozAdapter"],
-                    path: "./Sources/KidozSources"),
+        .target(name:"AATKit-Kidoz",
+                dependencies: ["AATKidoz", "AATKidozAdapter"],
+                path: "./Sources/KidozSources"),
 
-            .target(name:"AATKit-PubNative",
-                    dependencies: ["HyBid", "OMSDK_Pubnativenet", "ATOM", "AATPubNativeAdapter"],
-                    path: "./Sources/PubnativeSources"),
+        .target(name:"AATKit-PubNative",
+                dependencies: ["AATHyBid", "AATOMSDK_Pubnativenet", "AATATOM", "AATPubNativeAdapter"],
+                path: "./Sources/PubnativeSources"),
 
-            .target(name:"AATKit-Prebid",
-                    dependencies: ["PrebidMobile", "AATDFPPrebidAdapter"],
-                    path: "./Sources/PrebidSources"),
+        .target(name:"AATKit-Prebid",
+                dependencies: ["AATPrebidMobile", "AATDFPPrebidAdapter"],
+                path: "./Sources/PrebidSources"),
 
-            .target(name:"AATKit-Unity",
-                    dependencies: ["UnityAds", "AATUnityAdapter"],
-                    path: "./Sources/UnitySources"),
+        .target(name:"AATKit-Unity",
+                dependencies: ["AATUnityAds", "AATUnityAdapter"],
+                path: "./Sources/UnitySources"),
 
-            .target(name:"AATKit-Vungle",
-                    dependencies: ["VungleSDK", "AATVungleAdapter"],
-                    path: "./Sources/VungleSources"),
+        .target(name:"AATKit-Vungle",
+                dependencies: ["AATVungleSDK", "AATVungleAdapter"],
+                path: "./Sources/VungleSources"),
 
-            .target(name:"AATKit-Datonomy",
-                    dependencies: ["DatonomyKit", "AATDatonomyAdapter"],
-                    path: "./Sources/DatonomySources"),
+        .target(name:"AATKit-Datonomy",
+                dependencies: ["AATDatonomyKit", "AATDatonomyAdapter"],
+                path: "./Sources/DatonomySources"),
 
-            .target(name:"AATKit-Mintegral",
-                    dependencies: ["MTGSDK", "MTGSDKNativeAdvanced", "MTGSDKBanner", "MTGSDKNewInterstitial", "MTGSDKBidding", "MTGSDKReward", "MTGSDKCNAddition", "MTGSDKSplash", "MTGSDKInterstitial", "MTGSDKInterstitialVideo", "AATMintegralAdapter"],
-                    path: "./Sources/MintegralSources"),
+        .target(name:"AATKit-Mintegral",
+                dependencies: [
+                    "AATMTGSDK",
+                    "AATMTGSDKNativeAdvanced",
+                    "AATMTGSDKBanner",
+                    "AATMTGSDKNewInterstitial",
+                    "AATMTGSDKBidding",
+                    "AATMTGSDKReward",
+                    "AATMTGSDKCNAddition",
+                    "AATMTGSDKSplash",
+                    "AATMTGSDKInterstitial",
+                    "AATMTGSDKInterstitialVideo",
+                    "AATMintegralAdapter"
+                ],
+                path: "./Sources/MintegralSources"),
 
-            .target(name:"AATKit-SourcePointCMP",
-                    dependencies: ["ConsentViewController", "AATSourcePointCMPAdapter"],
-                    path: "./Sources/SourcePointSources"),
+        .target(name:"AATKit-SourcePointCMP",
+                dependencies: ["AATConsentViewController", "AATSourcePointCMPAdapter"],
+                path: "./Sources/SourcePointSources"),
 
-            .target(name:"AATKit-AppConsentCMP",
-                    dependencies: ["AppConsent", "AATAppConsentAdapter"],
-                    path: "./Sources/AppConsentCMP"),
+        .target(name:"AATKit-AppConsentCMP",
+                dependencies: ["AATAppConsent", "AATAppConsentAdapter"],
+                path: "./Sources/AppConsentCMP"),
 
-            .target(name:"AATKit-DisplayIO",
-                    dependencies: ["DisplayIO", "AATDisplayIOAdapter"],
-                    path: "./Sources/DisplayIOSources"),
+        .target(name:"AATKit-DisplayIO",
+                dependencies: ["AATDisplayIO", "AATDisplayIOAdapter"],
+                path: "./Sources/DisplayIOSources"),
         // Mark: Binary Targets
         // AATKit
-        .binaryTarget(name: "AATKit", path: "./Dependencies/AATKit/AATKit.xcframework"),
+            .binaryTarget(name: "AATKit", path: "./Dependencies/AATKit/AATKit.xcframework"),
 
         // AATAdMobMediationAdapter
         .binaryTarget(name: "AATAdMobMediationAdapter", path: "./Dependencies/AATAdMobMediationAdapter/AATAdMobMediationAdapter.xcframework"),
@@ -244,108 +268,108 @@ let package = Package(
         .binaryTarget(name: "AATAdMobDSPAdapter", path: "./Dependencies/AATKit/Adapters/AATAdMobDSPAdapter.xcframework"),
 
         // Amazon
-        .binaryTarget(name: "DTBiOSSDK", path: "./Dependencies/Amazon/DTBiOSSDK.xcframework"),
+        .binaryTarget(name: "AATDTBiOSSDK", path: "./Dependencies/Amazon/DTBiOSSDK.xcframework"),
 
         // Criteo
-        .binaryTarget(name: "CriteoPublisherSdk", path: "./Dependencies/Criteo/CriteoPublisherSdk.xcframework"),
+        .binaryTarget(name: "AATCriteoPublisherSdk", path: "./Dependencies/Criteo/CriteoPublisherSdk.xcframework"),
 
         // FeedAd
-        .binaryTarget(name: "FeedAd", path: "./Dependencies/FeedAd/FeedAd.xcframework"),
+        .binaryTarget(name: "AATFeedAd", path: "./Dependencies/FeedAd/FeedAd.xcframework"),
 
         // Ogury
-        .binaryTarget(name: "OguryCore", path: "./Dependencies/Ogury/OguryCore.xcframework"),
-        .binaryTarget(name: "OguryAds", path: "./Dependencies/Ogury/OguryAds.xcframework"),
-        .binaryTarget(name: "OMSDK_Ogury", path: "./Dependencies/Ogury/OMSDK_Ogury.xcframework"),
-        .binaryTarget(name: "OgurySdk", path: "./Dependencies/Ogury/OgurySdk.xcframework"),
+        .binaryTarget(name: "AATOguryCore", path: "./Dependencies/Ogury/OguryCore.xcframework"),
+        .binaryTarget(name: "AATOguryAds", path: "./Dependencies/Ogury/OguryAds.xcframework"),
+        .binaryTarget(name: "AATOMSDK_Ogury", path: "./Dependencies/Ogury/OMSDK_Ogury.xcframework"),
+        .binaryTarget(name: "AATOgurySdk", path: "./Dependencies/Ogury/OgurySdk.xcframework"),
 
         // Smaato
-        .binaryTarget(name: "OMSDK_Smaato", path: "./Dependencies/Smaato/OMSDK_Smaato.xcframework"),
-        .binaryTarget(name: "SmaatoSDKBanner", path: "./Dependencies/Smaato/SmaatoSDKBanner.xcframework"),
-        .binaryTarget(name: "SmaatoSDKCore", path: "./Dependencies/Smaato/SmaatoSDKCore.xcframework"),
-        .binaryTarget(name: "SmaatoSDKInterstitial", path: "./Dependencies/Smaato/SmaatoSDKInterstitial.xcframework"),
-        .binaryTarget(name: "SmaatoSDKNative", path: "./Dependencies/Smaato/SmaatoSDKNative.xcframework"),
-        .binaryTarget(name: "SmaatoSDKOpenMeasurement", path: "./Dependencies/Smaato/SmaatoSDKOpenMeasurement.xcframework"),
-        .binaryTarget(name: "SmaatoSDKOutstream", path: "./Dependencies/Smaato/SmaatoSDKOutstream.xcframework"),
-        .binaryTarget(name: "SmaatoSDKRewardedAds", path: "./Dependencies/Smaato/SmaatoSDKRewardedAds.xcframework"),
-        .binaryTarget(name: "SmaatoSDKRichMedia", path: "./Dependencies/Smaato/SmaatoSDKRichMedia.xcframework"),
-        .binaryTarget(name: "SmaatoSDKVideo", path: "./Dependencies/Smaato/SmaatoSDKVideo.xcframework"),
+        .binaryTarget(name: "AATOMSDK_Smaato", path: "./Dependencies/Smaato/OMSDK_Smaato.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKBanner", path: "./Dependencies/Smaato/SmaatoSDKBanner.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKCore", path: "./Dependencies/Smaato/SmaatoSDKCore.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKInterstitial", path: "./Dependencies/Smaato/SmaatoSDKInterstitial.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKNative", path: "./Dependencies/Smaato/SmaatoSDKNative.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKOpenMeasurement", path: "./Dependencies/Smaato/SmaatoSDKOpenMeasurement.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKOutstream", path: "./Dependencies/Smaato/SmaatoSDKOutstream.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKRewardedAds", path: "./Dependencies/Smaato/SmaatoSDKRewardedAds.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKRichMedia", path: "./Dependencies/Smaato/SmaatoSDKRichMedia.xcframework"),
+        .binaryTarget(name: "AATSmaatoSDKVideo", path: "./Dependencies/Smaato/SmaatoSDKVideo.xcframework"),
 
         //SmartAd
-        .binaryTarget(name: "SASDisplayKit", path: "./Dependencies/SmartAd/SASDisplayKit.xcframework"),
+        .binaryTarget(name: "AATSASDisplayKit", path: "./Dependencies/SmartAd/SASDisplayKit.xcframework"),
 
         // Tappx
-        .binaryTarget(name: "Tappx", path: "./Dependencies/Tappx/TappxFramework.xcframework"),
-        .binaryTarget(name: "OMSDK_Tappx", path: "./Dependencies/Tappx/OMSDK_Tappx.xcframework"),
+        .binaryTarget(name: "AATTappx", path: "./Dependencies/Tappx/TappxFramework.xcframework"),
+        .binaryTarget(name: "AATOMSDK_Tappx", path: "./Dependencies/Tappx/OMSDK_Tappx.xcframework"),
 
         // Teads
-        .binaryTarget(name: "TeadsSDK", path: "./Dependencies/TeadsSDK/TeadsSDK.xcframework"),
-        .binaryTarget(name: "OMSDK_Teadstv", path: "./Dependencies/TeadsSDK/OMSDK_Teadstv.xcframework"),
+        .binaryTarget(name: "AATTeadsSDK", path: "./Dependencies/TeadsSDK/TeadsSDK.xcframework"),
+        .binaryTarget(name: "AATOMSDK_Teadstv", path: "./Dependencies/TeadsSDK/OMSDK_Teadstv.xcframework"),
 
         // YOC
-        .binaryTarget(name: "VisxSDK", path: "./Dependencies/YOC/VisxSDK.xcframework"),
+        .binaryTarget(name: "AATVisxSDK", path: "./Dependencies/YOC/VisxSDK.xcframework"),
 
         // InMobi
-        .binaryTarget(name: "InMobiSDK", path: "./Dependencies/InMobi/InMobiSDK.xcframework"),
+        .binaryTarget(name: "AATInMobiSDK", path: "./Dependencies/InMobi/InMobiSDK.xcframework"),
 
         // IronSource
-        .binaryTarget(name: "IronSource", path: "./Dependencies/IronSource/IronSource.xcframework"),
+        .binaryTarget(name: "AATIronSource", path: "./Dependencies/IronSource/IronSource.xcframework"),
 
         // Kidoz
-        .binaryTarget(name: "Kidoz", path: "./Dependencies/Kidoz/KidozSDK.xcframework"),
+        .binaryTarget(name: "AATKidoz", path: "./Dependencies/Kidoz/KidozSDK.xcframework"),
 
         // PubNative
-        .binaryTarget(name: "HyBid", path: "./Dependencies/Pubnative/HyBid.xcframework"),
-        .binaryTarget(name: "OMSDK_Pubnativenet", path: "./Dependencies/Pubnative/OMSDK_Pubnativenet.xcframework"),
-        .binaryTarget(name: "ATOM", path: "./Dependencies/Pubnative/ATOM.xcframework"),
+        .binaryTarget(name: "AATHyBid", path: "./Dependencies/Pubnative/HyBid.xcframework"),
+        .binaryTarget(name: "AATOMSDK_Pubnativenet", path: "./Dependencies/Pubnative/OMSDK_Pubnativenet.xcframework"),
+        .binaryTarget(name: "AATATOM", path: "./Dependencies/Pubnative/ATOM.xcframework"),
 
         // Prebid
-        .binaryTarget(name: "PrebidMobile", path: "./Dependencies/Prebid/PrebidMobile.xcframework"),
+        .binaryTarget(name: "AATPrebidMobile", path: "./Dependencies/Prebid/PrebidMobile.xcframework"),
 
         // Unity
-        .binaryTarget(name: "UnityAds", path: "./Dependencies/Unity/UnityAds.xcframework"),
+        .binaryTarget(name: "AATUnityAds", path: "./Dependencies/Unity/UnityAds.xcframework"),
 
         // Vungle
-        .binaryTarget(name: "VungleSDK", path: "./Dependencies/Vungle/VungleAdsSDK.xcframework"),
+        .binaryTarget(name: "AATVungleSDK", path: "./Dependencies/Vungle/VungleAdsSDK.xcframework"),
 
         // Datonomy
-        .binaryTarget(name: "DatonomyKit", path: "./Dependencies/Datonomy/DatonomyKit.xcframework"),
+        .binaryTarget(name: "AATDatonomyKit", path: "./Dependencies/Datonomy/DatonomyKit.xcframework"),
 
         // AppNexusSDK - for future updates, check https://github.com/appnexus/mobile-sdk-ios-spm/blob/main/Package.swift
         .binaryTarget(
-            name: "OMSDK_Microsoft",
-            url: "https://adsdkprod.azureedge.net/mobile/ios/releases/9.2.1/dynamic/OMSDK_Microsoft.zip",
-            checksum: "f0b7cc1c45095a99bcd16e21250610a7614bbdf3d3c99e5f3ee8d762d9fe7dde"
+            name: "AATOMSDK_Microsoft",
+            url: "https://adsdkprod.azureedge.net/mobile/ios/releases/9.5.0/dynamic/OMSDK_Microsoft.zip",
+            checksum: "22c9115cb46ee6301d8ef8972c2b77af0f00c55f93bc8cd28817ae62da99b670"
         ),
         .binaryTarget(
-            name: "AppNexusSDK",
-            url: "https://adsdkprod.azureedge.net/mobile/ios/releases/9.2.1/dynamic/AppNexusSDKDynamic.zip",
-            checksum: "a122b9d51dd6c58aec384e1c65bd82d1da2fcdebcedf0cfb3e2b328bd9ced38b"
+            name: "AATAppNexusSDKTarget",
+            url: "https://adsdkprod.azureedge.net/mobile/ios/releases/9.5.0/dynamic/AppNexusSDKDynamic.zip",
+            checksum: "d9f48664619e1a51aa29d7a93cfcb561c015cd69c84aebf152c04ecf2c56f36f"
         ),
 
         // Mintegral
-        .binaryTarget(name: "MTGSDK", path:"./Dependencies/Mintegral/MTGSDK.xcframework"),
-        .binaryTarget(name: "MTGSDKNativeAdvanced", path:"./Dependencies/Mintegral/MTGSDKNativeAdvanced.xcframework"),
-        .binaryTarget(name: "MTGSDKBanner", path:"./Dependencies/Mintegral/MTGSDKBanner.xcframework"),
-        .binaryTarget(name: "MTGSDKNewInterstitial", path:"./Dependencies/Mintegral/MTGSDKNewInterstitial.xcframework"),
-        .binaryTarget(name: "MTGSDKBidding", path:"./Dependencies/Mintegral/MTGSDKBidding.xcframework"),
-        .binaryTarget(name: "MTGSDKReward", path:"./Dependencies/Mintegral/MTGSDKReward.xcframework"),
-        .binaryTarget(name: "MTGSDKCNAddition", path:"./Dependencies/Mintegral/MTGSDKCNAddition.xcframework"),
-        .binaryTarget(name: "MTGSDKSplash", path:"./Dependencies/Mintegral/MTGSDKSplash.xcframework"),
-        .binaryTarget(name: "MTGSDKInterstitial", path:"./Dependencies/Mintegral/MTGSDKInterstitial.xcframework"),
-        .binaryTarget(name: "MTGSDKInterstitialVideo", path:"./Dependencies/Mintegral/MTGSDKInterstitialVideo.xcframework"),
+        .binaryTarget(name: "AATMTGSDK", path:"./Dependencies/Mintegral/MTGSDK.xcframework"),
+        .binaryTarget(name: "AATMTGSDKNativeAdvanced", path:"./Dependencies/Mintegral/MTGSDKNativeAdvanced.xcframework"),
+        .binaryTarget(name: "AATMTGSDKBanner", path:"./Dependencies/Mintegral/MTGSDKBanner.xcframework"),
+        .binaryTarget(name: "AATMTGSDKNewInterstitial", path:"./Dependencies/Mintegral/MTGSDKNewInterstitial.xcframework"),
+        .binaryTarget(name: "AATMTGSDKBidding", path:"./Dependencies/Mintegral/MTGSDKBidding.xcframework"),
+        .binaryTarget(name: "AATMTGSDKReward", path:"./Dependencies/Mintegral/MTGSDKReward.xcframework"),
+        .binaryTarget(name: "AATMTGSDKCNAddition", path:"./Dependencies/Mintegral/MTGSDKCNAddition.xcframework"),
+        .binaryTarget(name: "AATMTGSDKSplash", path:"./Dependencies/Mintegral/MTGSDKSplash.xcframework"),
+        .binaryTarget(name: "AATMTGSDKInterstitial", path:"./Dependencies/Mintegral/MTGSDKInterstitial.xcframework"),
+        .binaryTarget(name: "AATMTGSDKInterstitialVideo", path:"./Dependencies/Mintegral/MTGSDKInterstitialVideo.xcframework"),
 
         // Meta
-        .binaryTarget(name: "FBAudienceNetwork", path:"./Dependencies/Facebook/FBAudienceNetwork.xcframework"),
-        .binaryTarget(name: "MetaAdapter", path:"./Dependencies/Facebook/MetaAdapter.xcframework"),
+        .binaryTarget(name: "AATFBAudienceNetwork", path:"./Dependencies/Facebook/FBAudienceNetwork.xcframework"),
+        .binaryTarget(name: "AATMetaAdapter", path:"./Dependencies/Facebook/MetaAdapter.xcframework"),
 
         // AppConsent
-        .binaryTarget(name: "AppConsent", path:"./Dependencies/AppConsentCMP/AppConsent.xcframework"),
+        .binaryTarget(name: "AATAppConsent", path:"./Dependencies/AppConsentCMP/AppConsent.xcframework"),
 
         // SourcePoint
-        .binaryTarget(name: "ConsentViewController", path: "./Dependencies/SourcePoint/ConsentViewController.xcframework"),
+        .binaryTarget(name: "AATConsentViewController", path: "./Dependencies/SourcePoint/ConsentViewController.xcframework"),
 
         // DisplayIO
-        .binaryTarget(name: "DisplayIO", path:"./Dependencies/DisplayIO/DIOSDK.xcframework"),
+        .binaryTarget(name: "AATDisplayIO", path:"./Dependencies/DisplayIO/DIOSDK.xcframework"),
 
         // AATKit Adapters
         .binaryTarget(name: "AATAmazonAdapter", path: "./Dependencies/AATKit/Adapters/AATAmazonAdapter.xcframework"),


### PR DESCRIPTION
- Rename SPM packages to have AAT prefixes.
- Use the new API `.package(url: "<URL>", .exact("<VERISON>"))` and get rid of the depricated one.